### PR TITLE
Make cmake build cross-platform capable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ ExternalProject_Add(oasis3-mct
     GIT_TAG           62c541bead9b82c5d48da0496c8d414659dfd953
     CONFIGURE_COMMAND ""
     BUILD_IN_SOURCE 1
-    BUILD_COMMAND make nci
+    BUILD_COMMAND make ${PLATFORM}
     INSTALL_COMMAND cmake -E echo "Skipping json-fortran install step."
 )
 ExternalProject_Get_property(oasis3-mct BINARY_DIR)

--- a/build_on_raijin.sh
+++ b/build_on_raijin.sh
@@ -11,7 +11,7 @@ MYDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $MYDIR && \
 mkdir -p build && \
 cd build && \
-cmake ../ && \
+cmake -DPLATFORM=nci ../ && \
 make ; \
 
 cd -


### PR DESCRIPTION
Made cmake build cross-platform capable by using PLATFORM environment var passed to oasis build

This is in part designed to address https://github.com/OceansAus/access-om2/issues/118

There is no script for the other platform or a build target in OASIS3-mct, but if those elements are added the CMake build can work with them.