### PR TITLE
Follow up to remove platform specific build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -x
+
+PLATFORM=$1
+
+MYDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+cd $MYDIR && \
+mkdir -p build && \
+cd build && \
+cmake -DPLATFORM=$PLATFORM ../ && \
+make VERBOSE=1; \
+
+cd -

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 PLATFORM=$1
 

--- a/build_on_raijin.sh
+++ b/build_on_raijin.sh
@@ -6,12 +6,4 @@ module load netcdf/4.4.1.1
 module load intel-fc/17.0.1.132
 module load openmpi/1.10.2
 
-MYDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-cd $MYDIR && \
-mkdir -p build && \
-cd build && \
-cmake -DPLATFORM=nci ../ && \
-make ; \
-
-cd -
+./build.sh nci


### PR DESCRIPTION
Adds more support to solve https://github.com/OceansAus/access-om2/issues/118

Builds on previous PR https://github.com/OceansAus/libaccessom2/pull/6

Makes a platform agnostic build script, which `build_on_raijin.sh` calls.