### PR TITLE
Fix #24: don't use FindNetCDF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,14 +29,14 @@ else()
   endif()
 endif()
 
-if("${NETCDF_DIR}" STREQUAL "")
-  execute_process(COMMAND nf-config --prefix OUTPUT_VARIABLE NETCDF_DIR
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-endif()
+#if("${NETCDF_DIR}" STREQUAL "")
+#  execute_process(COMMAND nf-config --prefix OUTPUT_VARIABLE NETCDF_DIR
+#    OUTPUT_STRIP_TRAILING_WHITESPACE)
+#endif()
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
-set (NETCDF_F90 "YES")
-find_package(NetCDF REQUIRED)
-include_directories(${NETCDF_F90_INCLUDE_DIRS})
+# set (NETCDF_F90 "YES")
+# find_package(NetCDF REQUIRED)
+# include_directories(${NETCDF_F90_INCLUDE_DIRS})
 
 # compiler flags for gfortran
 if(CMAKE_Fortran_COMPILER_ID MATCHES GNU)
@@ -154,15 +154,15 @@ set_target_properties(accessom2 PROPERTIES IMPORTED_LOCATION ${LIBACCESSOM2})
 # yatm executable
 file(GLOB ATM_SOURCES atm/src/*.F90)
 add_executable(yatm.exe ${ATM_SOURCES})
-target_link_libraries(yatm.exe accessom2 ${NETCDF_LIBRARIES} ${MPI_Fortran_LIBRARIES})
+target_link_libraries(yatm.exe accessom2 netcdff ${MPI_Fortran_LIBRARIES})
 
 # ice stub executable
 file(GLOB ICE_STUB_SOURCES ice_stub/src/*.F90)
 add_executable(ice_stub.exe ${ICE_STUB_SOURCES})
-target_link_libraries(ice_stub.exe accessom2 ${NETCDF_LIBRARIES} ${MPI_Fortran_LIBRARIES})
+target_link_libraries(ice_stub.exe accessom2 netcdff ${MPI_Fortran_LIBRARIES})
 
 # ocean stub executable
 file(GLOB OCEAN_STUB_SOURCES ocean_stub/src/*.F90)
 add_executable(ocean_stub.exe ${OCEAN_STUB_SOURCES})
-target_link_libraries(ocean_stub.exe accessom2 ${NETCDF_LIBRARIES} ${MPI_Fortran_LIBRARIES})
+target_link_libraries(ocean_stub.exe accessom2 netcdff ${MPI_Fortran_LIBRARIES})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,14 +29,7 @@ else()
   endif()
 endif()
 
-#if("${NETCDF_DIR}" STREQUAL "")
-#  execute_process(COMMAND nf-config --prefix OUTPUT_VARIABLE NETCDF_DIR
-#    OUTPUT_STRIP_TRAILING_WHITESPACE)
-#endif()
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
-# set (NETCDF_F90 "YES")
-# find_package(NetCDF REQUIRED)
-# include_directories(${NETCDF_F90_INCLUDE_DIRS})
 
 # compiler flags for gfortran
 if(CMAKE_Fortran_COMPILER_ID MATCHES GNU)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ set_property(TARGET jsonfortran PROPERTY IMPORTED_LOCATION ${BINARY_DIR}/lib/lib
 # json-fortran external project
 ExternalProject_Add(oasis3-mct
     GIT_REPOSITORY    https://github.com/COSIMA/oasis3-mct.git
-    GIT_TAG           3dd0d4cf2947dbad8928b7f2803da5e20970fa13
+    GIT_TAG           43e3686890accbf496aa1f450907d00bc14e2ed4
     CONFIGURE_COMMAND ""
     BUILD_IN_SOURCE 1
     BUILD_COMMAND make ${PLATFORM}


### PR DESCRIPTION
See https://github.com/COSIMA/libaccessom2/issues/24
Directly specify `netcdff` as a linked library rather than using `FindNetCDF.make`, which doesn't work on raijin.
This change relies instead on the module load machinery, so reduces portability of the code.