### PR TITLE
use netcdf/4.7.4 to match what CICE uses in ACCESS-OM2

### DIFF
--- a/build_on_gadi.sh
+++ b/build_on_gadi.sh
@@ -2,7 +2,7 @@
 
 module purge
 module load intel-compiler/2019.5.281
-module load netcdf/4.7.1
+module load netcdf/4.7.4
 module load openmpi/4.0.2
 
 MYDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"


### PR DESCRIPTION
CICE now uses netcdf/4.7.4p for PIO in access-om2 so it's probably best to match that here (with the serial version).