### PR TITLE
Explicit support for building outside a git repo

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-latest]
+        os: [ubuntu-20.04]
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
     

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,24 +108,22 @@ set_property(TARGET mpeu PROPERTY IMPORTED_LOCATION ${BINARY_DIR}/Linux/lib/libm
 set_property(TARGET psmile.MPI1 PROPERTY IMPORTED_LOCATION ${BINARY_DIR}/Linux/lib/libpsmile.MPI1.a)
 set_property(TARGET scrip PROPERTY IMPORTED_LOCATION ${BINARY_DIR}/Linux/lib/libscrip.a)
 
-# Get the current working branch
-execute_process(
-  COMMAND git config --get remote.origin.url
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-  OUTPUT_VARIABLE GIT_URL
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
 # Get the latest abbreviated commit hash of the working branch
 execute_process(
   COMMAND git rev-parse HEAD
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   OUTPUT_VARIABLE GIT_COMMIT_HASH
+  RESULT_VARIABLE STATUS
   OUTPUT_STRIP_TRAILING_WHITESPACE
+  ERROR_QUIET
 )
 
+if(STATUS AND NOT STATUS EQUAL 0)
+  set(GIT_COMMIT_HASH "NA")
+  message(STATUS "Not in a git repo, GIT_COMMIT_HASH set to ${GIT_COMMIT_HASH}")
+endif()
+
 add_definitions("-DGIT_COMMIT_HASH='${GIT_COMMIT_HASH}'")
-add_definitions("-DGIT_URL='${GIT_URL}'")
 
 # libutil.a library
 file(GLOB LIB_SOURCES libutil/src/*.F90)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,8 +119,8 @@ execute_process(
 )
 
 if(STATUS AND NOT STATUS EQUAL 0)
-  set(GIT_COMMIT_HASH "NA")
-  message(STATUS "Not in a git repo, GIT_COMMIT_HASH set to ${GIT_COMMIT_HASH}")
+  set(GIT_COMMIT_HASH "")
+  message(STATUS "Not in a git repo, GIT_COMMIT_HASH set to '${GIT_COMMIT_HASH}'")
 endif()
 
 add_definitions("-DGIT_COMMIT_HASH='${GIT_COMMIT_HASH}'")


### PR DESCRIPTION
Explicit support for building outside a git repo: Check return status of git command and set `GIT_COMMIT_HASH` to "NA" if error. Previous behaviour emitted error message and `GIT_COMMIT_HASH` was an empty string.

Deleted unused build variable `GIT_URL`.

Closes #81 

